### PR TITLE
fix(obs-scala-cli): prevent warinings after block evaluation

### DIFF
--- a/ob-scala-cli.el
+++ b/ob-scala-cli.el
@@ -60,7 +60,7 @@
 
 (defun ob-scala-cli-expand-body (body)
   "Expand the BODY to evaluate."
-  (format "{\n %s\n%s\n}" body ob-scala-cli-eval-needle))
+  (format "{\n%s\n\n}%s" body ob-scala-cli-eval-needle))
 
 (defun ob-scala-cli--trim-result (str)
   "Trim the result string.


### PR DESCRIPTION
Thanks for this package. 

I've found that using `ob-scala-cli` you get warinings and `|}` in output. I think that's due to wrong format string in `ob-scala-cli-expand-body`.
Two issues: 
1. Space before the code which triggers indent warinings for scala 3.
2. `ob-scala-cli-eval-needle` being sent (formatted) before closing bracket which resulted in bracket being reflected in source block result.

Here is the before:
![image](https://github.com/ag91/scala-cli-repl/assets/23096821/b10fc25c-4012-46f8-88ad-f720453c4051)

And after:
![image](https://github.com/ag91/scala-cli-repl/assets/23096821/50908fc6-ecf1-41ad-b6e2-14a43f80be45)

Hope it helps ;) 