### PR TITLE
:no-closure for org-babel

### DIFF
--- a/ob-scala-cli.el
+++ b/ob-scala-cli.el
@@ -61,9 +61,11 @@
 (defvar ob-scala-cli-last-params nil
   "Used to compare if params have changed before restarting REPL to update configuration.")
 
-(defun ob-scala-cli-expand-body (body)
+(defun ob-scala-cli-expand-body (body disable-closure)
   "Expand the BODY to evaluate."
-  (format "{\n%s\n\n}%s" body ob-scala-cli-eval-needle))
+  (format (if disable-closure "%s\n\n%s" "{\n%s\n\n}%s")
+          body
+          ob-scala-cli-eval-needle))
 
 (defun ob-scala-cli--trim-result (str)
   "Trim the result string.
@@ -132,7 +134,8 @@ Argument PARAMS the header arguments."
        (when ob-scala-cli-debug-p (print str))
        (setq ob-scala-cli-eval-result (concat ob-scala-cli-eval-result str)))))
 
-  (let ((full-body (ob-scala-cli-expand-body body)))
+  (let* ((disable-closure (assoc :no-closure params))
+         (full-body (ob-scala-cli-expand-body body disable-closure)))
     (comint-send-string scala-cli-repl-buffer-name full-body)
     (comint-send-string scala-cli-repl-buffer-name "\n"))
 


### PR DESCRIPTION
# Issue

Now I can't send objects to the REPL, e.g.:
```org
#+begin_src scala :scala-version "2.13.11" :jvm 11
object Test {
}
#+end_src

#+RESULTS:
: ^
:        error: eof expected but '}' found.
```

# Solution

We could introduce `:no-closure` parameter to optinally disable wrapping curly braces, e.g.:
```
#+begin_src scala :scala-version "2.13.11" :jvm 11 :no-closure
object Test {
}
#+end_src

#+RESULTS:
```

Not sure about an implementation and terminology, I'm not a lisp programmer and got "closure" from "scala-cli-repl-use-closure-for-eval" for consistency. 