### PR TITLE
Org-babel improvements

### DIFF
--- a/README.org
+++ b/README.org
@@ -55,7 +55,8 @@ chmod +x scala-cli
 sudo mv scala-cli /usr/local/bin/scala-cli
 #+end_src
 
-** Org Babel supported parameters 
+** Org Babel
+*** Supported parameters
 :PROPERTIES:
 :CREATED:  [2023-07-20 Thu 21:11]
 :ID:       83d7d014-62dc-457c-9210-ec05661265fb
@@ -75,21 +76,46 @@ Currently supported header parameters are:
 
   you can set the JVM version to use for evaluating your code
 
-- :no-closure
-
-  by default the code is evaluated in a scope to not leak variables in the global scope of the REPL, but there may be cases where this causes errors like
-
-  #+begin_src text
-#+RESULTS:
-: ^
-:        error: eof expected but '}' found.
-```
-  #+end_src
-
-  this header fixes those by removing the extra scope.
+**Note**: the code is evaluated in a global scope by default, so you can use variables and functions across the blocks.
+If you don't want definitions to leak, wrap them in curly braces.
   
 If you enjoy Elisp, you can get an updated list of valid parameters
 evaluating =ob-scala-cli-supported-params=.
+
+Also see usage [[ob-scala-cli-tests.org][examples]].
+
+*** Useful options
+
+- =ob-scala-cli-default-params=
+
+  you can define default parameters locally or globally and don't specify them each block. Example:
+
+  #+begin_src elisp :results none
+  (setq ob-scala-cli-default-params '(:scala-version "2.13.11" :jvm 17))
+  #+end_src
+
+  then just write a code:
+
+  #+begin_src scala
+  println(s"""
+   |Scala version: ${scala.util.Properties.versionString}
+   |JVM version: ${System.getProperty("java.version")}""".stripMargin)
+  #+end_src
+
+  #+RESULTS:
+  : Scala version: version 2.13.11
+  : JVM version: 17.0.8
+
+  **Note**: if you use dependencies in multiple blocks specify also =:deps= for faster evaluation.
+
+- =scala-cli-ob-force-kill=
+
+  if you run blocks with different options (Scala version, JVM version, deps, etc.), you could face with an error:
+  #+begin_quote
+  Buffer "*Scala-Cli*" has a running process; kill it? (y or n)
+  #+end_quote
+
+  Set this flag if you want to forcely kill the process and the buffer.
 
 ** Similar projects
 :PROPERTIES:

--- a/ob-scala-cli-tests.org
+++ b/ob-scala-cli-tests.org
@@ -12,19 +12,21 @@ Run tests:
 
 Change if needed:
 #+begin_src elisp :results none
-(setq-local scala-cli-ob-force-kill t ; Don't ask to kill the buffer if options changed
-            jvm 17
+(setq-local jvm 17
             scala2 "2.13.11"
             scala3 "3.3.0"
             dep-os-lib "com.lihaoyi::os-lib:0.9.1"
             dep-pprint "com.lihaoyi::pprint:0.7.0")
+
+(setq-local scala-cli-ob-force-kill t ; Don't ask to kill the buffer if options changed
+            ob-scala-cli-default-params `(:scala-version ,scala2 :jvm ,jvm)) ; Default options
 #+end_src
 
 It is expected that results at least the same.
 
 * Tests
 ** Simple one-liner
-#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm)
+#+begin_src scala
 1 + 1
 #+end_src
 
@@ -33,7 +35,7 @@ It is expected that results at least the same.
 
 ** Compilation errors in Scala 2.13
 *** Without a wrapping object
-#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm)
+#+begin_src scala
 def always1(x: Int): Int = 1
 def foo(x: Int): Int = println("error")
 def id(x: Int): Int = x
@@ -52,7 +54,7 @@ def id(x: Int): Int = x
 It shows a wrong error line, because Scala 2.13 doesn't allow top level definitions outside package objects.
 
 *** With a wrapping object
-#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm)
+#+begin_src scala
 object Test {
   def always1(x: Int): Int = 1
   def foo(x: Int): Int = println("error")
@@ -68,7 +70,7 @@ object Test {
 :         required: Int
 
 ** Function definition
-#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm)
+#+begin_src scala
 def increment(x: Int): Int = x + 1
 #+end_src
 
@@ -76,7 +78,7 @@ def increment(x: Int): Int = x + 1
 : def increment(x: Int): Int
 
 ** Usage of the function defined in one of previous blocks
-#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm)
+#+begin_src scala
 increment(1)
 #+end_src
 
@@ -84,7 +86,7 @@ increment(1)
 : val res1: Int = 2
 
 ** Dependency
-#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm) :dep (list dep-os-lib)
+#+begin_src scala :dep (list dep-os-lib)
 {
   val file = os.pwd / "ob-scala-cli-tests.org"
   println(s"Is ${file.last} a file? ${os.isFile(file)}")
@@ -114,7 +116,7 @@ If you want to preserve definitions between org src blocks, either:
   and don't override options in blocks.
 
 ** Multiple dependencies
-#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm) :dep (list dep-os-lib dep-pprint)
+#+begin_src scala :dep (list dep-os-lib dep-pprint)
 {
   val file = os.pwd / "ob-scala-cli-tests.org"
   println(s"Is ${file.last} a file? ${os.isFile(file)}")
@@ -132,7 +134,7 @@ pprint.pprintln(Seq(1, 2, 3), width = 5)
 
 ** Compilation errors in Scala 3
 *** Without wrapping object
-#+begin_src scala :scala-version (format "%s" scala3) :jvm (format "%s" jvm)
+#+begin_src scala :scala-version (format "%s" scala3)
 def always1(x: Int): Int = 1
 def foo(x: Int): Int = println("error")
 def id(x: Int): Int = x

--- a/ob-scala-cli-tests.org
+++ b/ob-scala-cli-tests.org
@@ -1,0 +1,146 @@
+* Testing
+Run tests:
+#+begin_src elisp :results none
+(let ((process (get-buffer-process "*Scala-Cli*"))
+      (current-pos (point)))
+  (save-excursion
+    (while (org-babel-next-src-block 1)
+      (unless (= (org-element-property :begin (org-element-at-point)) current-pos)
+        (org-babel-remove-result-one-or-many nil)
+        (org-babel-execute-src-block)))))
+#+end_src
+
+Change if needed:
+#+begin_src elisp :results none
+(setq-local scala-cli-ob-force-kill t ; Don't ask to kill the buffer if options changed
+            jvm 17
+            scala2 "2.13.11"
+            scala3 "3.3.0"
+            dep-os-lib "com.lihaoyi::os-lib:0.9.1"
+            dep-pprint "com.lihaoyi::pprint:0.7.0")
+#+end_src
+
+It is expected that results at least the same.
+
+* Tests
+** Simple one-liner
+#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm)
+1 + 1
+#+end_src
+
+#+RESULTS:
+: val res0: Int = 2
+
+** Compilation errors in Scala 2.13
+*** Without wrapping object
+#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm)
+def always1(x: Int): Int = 1
+def foo(x: Int): Int = println("error")
+def id(x: Int): Int = x
+#+end_src
+
+#+RESULTS:
+: def always1(x: Int): Int
+:        def foo(x: Int): Int = println("error")
+:                                      ^
+: On line 1: error: type mismatch;
+:         found   : Unit
+:         required: Int
+: def id(x: Int): Int
+
+**** Note
+It shows a wrong error line, because Scala 2.13 doesn't allow top level definitions outside package objects.
+
+*** With wrapping object
+#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm)
+object Test {
+  def always1(x: Int): Int = 1
+  def foo(x: Int): Int = println("error")
+  def id(x: Int): Int = x
+}
+#+end_src
+
+#+RESULTS:
+: def foo(x: Int): Int = println("error")
+:                                        ^
+: On line 3: error: type mismatch;
+:         found   : Unit
+:         required: Int
+
+** Function definition
+#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm)
+def increment(x: Int): Int = x + 1
+#+end_src
+
+#+RESULTS:
+: def increment(x: Int): Int
+
+** Usage of the function defined in one of previous blocks
+#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm)
+increment(1)
+#+end_src
+
+#+RESULTS:
+: val res1: Int = 2
+
+** Dependency
+#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm) :dep (list dep-os-lib)
+{
+  val file = os.pwd / "ob-scala-cli-tests.org"
+  println(s"Is ${file.last} a file? ${os.isFile(file)}")
+}
+#+end_src
+
+** Previous definitions lost after changing options
+#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm) :dep (list dep-os-lib)
+increment(1)
+#+end_src
+
+#+RESULTS:
+: increment(1)
+:        ^
+: On line 1: error: not found: value increment
+
+*** Note
+If you want to preserve definitions between org src blocks, either:
+- Define same options in all blocks;
+- Set default options somewhere, for example in the beginning of the org file:
+  #+begin_quote
+  # -*- ob-scala-cli-default-params: '(:scala-version "2.13.11" :jvm 17 :dep '("com.lihaoyi::os-lib:0.9.1" "com.lihaoyi::pprint:0.7.0")); -*-
+  #+end_quote
+  and don't override options in blocks.
+
+** Multiple dependencies
+#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm) :dep (list dep-os-lib dep-pprint)
+{
+  val file = os.pwd / "ob-scala-cli-tests.org"
+  println(s"Is ${file.last} a file? ${os.isFile(file)}")
+}
+pprint.pprintln(Seq(1, 2, 3), width = 5)
+#+end_src
+
+#+RESULTS:
+: Is ob-scala-cli-tests.org a file? true
+: List(
+:   1,
+:   2,
+:   3
+: )
+
+** Compilation errors in Scala 3
+*** Without wrapping object
+#+begin_src scala :scala-version (format "%s" scala3) :jvm (format "%s" jvm)
+def always1(x: Int): Int = 1
+def foo(x: Int): Int = println("error")
+def id(x: Int): Int = x
+#+end_src
+
+#+RESULTS:
+: -- [E007] Type Mismatch Error: -------------------------------------------------
+: 2 |def foo(x: Int): Int = println("error")
+:   |                       ^^^^^^^^^^^^^^^^
+:   |                       Found:    Unit
+:   |                       Required: Int
+:   |
+:   | longer explanation available when compiling with `-explain`
+: 1 error found

--- a/ob-scala-cli-tests.org
+++ b/ob-scala-cli-tests.org
@@ -32,7 +32,7 @@ It is expected that results at least the same.
 : val res0: Int = 2
 
 ** Compilation errors in Scala 2.13
-*** Without wrapping object
+*** Without a wrapping object
 #+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm)
 def always1(x: Int): Int = 1
 def foo(x: Int): Int = println("error")
@@ -51,7 +51,7 @@ def id(x: Int): Int = x
 **** Note
 It shows a wrong error line, because Scala 2.13 doesn't allow top level definitions outside package objects.
 
-*** With wrapping object
+*** With a wrapping object
 #+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm)
 object Test {
   def always1(x: Int): Int = 1
@@ -90,6 +90,9 @@ increment(1)
   println(s"Is ${file.last} a file? ${os.isFile(file)}")
 }
 #+end_src
+
+#+RESULTS:
+: Is ob-scala-cli-tests.org a file? true
 
 ** Previous definitions lost after changing options
 #+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm) :dep (list dep-os-lib)

--- a/ob-scala-cli-tests.org
+++ b/ob-scala-cli-tests.org
@@ -2,11 +2,19 @@
 Run tests:
 #+begin_src elisp :results none
 (let ((current-pos (point)))
-  (save-excursion
+  ;; Remove RESULTS blocks to know where we stopped
+  (goto-char (point-min))
+  (ignore-errors
     (while (org-babel-next-src-block 1)
-      (unless (= (org-element-property :begin (org-element-at-point)) current-pos)
-        (org-babel-remove-result-one-or-many nil)
-        (org-babel-execute-src-block)))))
+      (org-babel-remove-result-one-or-many nil)))
+
+  ;; Execute code blocks
+  (goto-char current-pos)
+  (while (org-babel-next-src-block 1)
+    (unless (= (org-element-property :begin (org-element-at-point)) current-pos)
+      (org-babel-execute-src-block)))
+
+  (goto-char current-pos))
 #+end_src
 
 Change if needed:
@@ -19,6 +27,8 @@ Change if needed:
 
 (setq-local scala-cli-ob-force-kill t ; Don't ask to kill the buffer if options changed
             ob-scala-cli-default-params `(:scala-version ,scala2 :jvm ,jvm)) ; Default options
+
+(ob-scala-cli-kill-buffer)
 #+end_src
 
 It is expected that results at least the same.

--- a/ob-scala-cli-tests.org
+++ b/ob-scala-cli-tests.org
@@ -1,8 +1,7 @@
 * Testing
 Run tests:
 #+begin_src elisp :results none
-(let ((process (get-buffer-process "*Scala-Cli*"))
-      (current-pos (point)))
+(let ((current-pos (point)))
   (save-excursion
     (while (org-babel-next-src-block 1)
       (unless (= (org-element-property :begin (org-element-at-point)) current-pos)
@@ -85,8 +84,28 @@ increment(1)
 #+RESULTS:
 : val res1: Int = 2
 
+** Isolate definitions
+#+begin_src scala
+{
+  def foo(x: Int): Int = x + 1
+  foo(2)
+}
+#+end_src
+
+#+RESULTS:
+: val res2: Int = 3
+
+#+begin_src scala
+foo(3)
+#+end_src
+
+#+RESULTS:
+: foo(3)
+:        ^
+: On line 1: error: not found: value foo
+
 ** Dependency
-#+begin_src scala :dep (list dep-os-lib)
+#+begin_src scala :dep `(,dep-os-lib)
 {
   val file = os.pwd / "ob-scala-cli-tests.org"
   println(s"Is ${file.last} a file? ${os.isFile(file)}")
@@ -97,7 +116,7 @@ increment(1)
 : Is ob-scala-cli-tests.org a file? true
 
 ** Previous definitions lost after changing options
-#+begin_src scala :scala-version (format "%s" scala2) :jvm (format "%s" jvm) :dep (list dep-os-lib)
+#+begin_src scala :dep `(,dep-os-lib)
 increment(1)
 #+end_src
 
@@ -116,7 +135,7 @@ If you want to preserve definitions between org src blocks, either:
   and don't override options in blocks.
 
 ** Multiple dependencies
-#+begin_src scala :dep (list dep-os-lib dep-pprint)
+#+begin_src scala :dep `(,dep-os-lib ,dep-pprint)
 {
   val file = os.pwd / "ob-scala-cli-tests.org"
   println(s"Is ${file.last} a file? ${os.isFile(file)}")

--- a/ob-scala-cli.el
+++ b/ob-scala-cli.el
@@ -108,6 +108,7 @@ Argument PARAMS the header arguments."
          (ob-scala-cli-eval-result ""))
     (unless (and (comint-check-proc scala-cli-repl-buffer-name) (equal scala-cli-params ob-scala-cli--last-params))
       (ignore-errors (ob-scala-cli--kill-buffer))
+      (sit-for 0.5)
       (save-window-excursion
         (let ((scala-cli-repl-program-args scala-cli-params))
           (scala-cli-repl)))

--- a/ob-scala-cli.el
+++ b/ob-scala-cli.el
@@ -191,7 +191,7 @@ header is defined, we set it to our temporary Scala script."
          (s-params (s-join " " (ob-scala-cli--params params)))
          (deps (plist-get params ':dep))
          (version (plist-get params ':scala-version))
-         (file (ob-scala-cli--mk-lsp-file info))
+         (file (file-truename (ob-scala-cli--mk-lsp-file info)))
          (dir (file-name-directory file))
          (default-directory dir)) ; to change the working directory for shell-command
     (when (with-demoted-errors "Error: %S" (require 'lsp-metals))

--- a/scala-cli-repl.el
+++ b/scala-cli-repl.el
@@ -83,11 +83,9 @@ to work around that."
 (defvar scala-cli-repl-program-local-args '()
   "Local args for scala-cli term repl program.")
 
-(defvar scala-cli-repl--process nil)
-
 (defun scala-cli-repl-get-process ()
   "Return the active process associated with Scala CLI buffer."
-  scala-cli-repl--process)
+  (get-buffer-process scala-cli-repl-buffer-name))
 
 (defun scala-cli-repl-get-buffer ()
   "Return the current Scala CLI buffer."
@@ -177,7 +175,6 @@ Argument FILE-NAME the file name."
                                scala-cli-repl-program
                                nil
                                scala-cli-repl-program-local-args)))
-      (setq scala-cli-repl--process (get-buffer-process proc-buffer))
       (with-current-buffer proc-buffer
         (term-char-mode)
         (term-set-escape-char ?\C-x)

--- a/scala-cli-repl.el
+++ b/scala-cli-repl.el
@@ -1,4 +1,4 @@
-;;; scala-cli-repl.el --- Scala CLI REPL in term mode. -*- lexical-binding: t; -*-
+;;; scala-cli-repl.el --- Scala CLI REPL in term mode.
 
 ;; Copyright (C) 2023 Andrea
 
@@ -170,18 +170,18 @@ Argument FILE-NAME the file name."
                      scala-cli-repl-program
                      (s-join " " scala-cli-repl-program-local-args)))
 
-    (let* ((proc-buffer (apply 'term-ansi-make-term
-                               scala-cli-repl-buffer-name
-                               scala-cli-repl-program
-                               nil
-                               scala-cli-repl-program-local-args)))
-      (with-current-buffer proc-buffer
-        (term-char-mode)
-        (term-set-escape-char ?\C-x)
-        (setq-local term-prompt-regexp scala-cli-repl-prompt-regex)
-        (setq-local term-scroll-show-maximum-output t)
-        (setq-local term-scroll-to-bottom-on-output t)
-        (run-hooks 'scala-cli-repl-run-hook))))
+    (with-current-buffer
+        (apply 'term-ansi-make-term
+               scala-cli-repl-buffer-name
+               scala-cli-repl-program
+               nil
+               scala-cli-repl-program-local-args)
+      (term-char-mode)
+      (term-set-escape-char ?\C-x)
+      (setq-local term-prompt-regexp scala-cli-repl-prompt-regex)
+      (setq-local term-scroll-show-maximum-output t)
+      (setq-local term-scroll-to-bottom-on-output t)
+      (run-hooks 'scala-cli-repl-run-hook)))
 
   (pop-to-buffer scala-cli-repl-buffer-name))
 


### PR DESCRIPTION
I saw no compilation errors when use the `:no-closure` switch. Then I found another issues and more and more. So here is a PR. I should do separate PRs, but it was easier for me to fix issues in one PR (sorry).
Feel free to close this PR and take only required changes. Hope this will help someone.

# Changes

- Use `:load` in Scala REPL instead of writing a code line-by-line. This improves errors and allows to get rid of `:no-closure` switch;
- Added tests, those also demonstrate the usage of org-babel integration;
- Default parameters in `ob-scala-cli-default-params`;
- Added `scala-cli-ob-force-kill` flag to force kill Scala CLI buffer if changed a Scala/JVM version or dependencies;
- `ob-scala-cli-lsp-org` should not add `:tangle` if it already exists;
- shell-command uses `scala-cli-repl-program`;
- defcustom for all options those could be customized;
- plist instead of alist for easier customize (also, there are few values, so it doesn't affect the performance);
- Updated Package-Requires, sorry emacs < 28.1 users;
- Removed `ob-scala-cli-eval-result`, because it seems we don't need to define it globally;
- Fixed freezes: "Waiting for scala-cli to start...""

I wrote below, why I changed implementation to passing `:file` command.

# No compilation errors issue

I see compilation errors only if I run a block without `:no-closure` option.

## Without :no-closure
```org
#+begin_src scala :scala-version "2.13.11" :jvm 11
def foo(a: Int): Int = a

def bar(a: Int): Int = {
  println("error")
}

def baz(a: Int): Int = a
#+end_src

#+RESULTS:
: println("error")
:                 ^
: On line 5: error: type mismatch;
:         found   : Unit
:         required: Int
```

\*Scala-Cli\* output:
```
scala> {
     | def foo(a: Int): Int = a
     |
     | def bar(a: Int): Int = {
     |   println("error")
     | }
     |
     | def baz(a: Int): Int = a
     |
     | };;;;;;;;;
         println("error")
                ^
On line 5: error: type mismatch;
        found   : Unit
        required: Int
```

## With :no-closure
But there is no error if I add `:no-closure` switch:

```org
#+begin_src scala :no-closure :scala-version "2.13.11" :jvm 11
object Foo {
  def foo(a: Int): Int = a
}

object Bar {
  def bar(a: Int): Int = {
    println("error")
  }
}

object Baz {
  def baz(a: Int): Int = a
}
#+end_src

#+RESULTS:
```

\*Scala-Cli\* output:
```
scala> object Foo {
     |   def foo(a: Int): Int = a
     | }
object Foo

scala>

scala> object Bar {
     |   def bar(a: Int): Int = {
     |     println("error")
     |   }
     | }
           println("error")
                  ^
On line 3: error: type mismatch;
        found   : Unit
        required: Int

scala>

scala> object Baz {
     |   def baz(a: Int): Int = a
     | }
object Baz

scala>

scala> ;;;;;;;;;
```

## Why

This happens because we split an output by `ob-scala-cli-eval-needle` in:
```elisp
(defun ob-scala-cli--trim-result (str)
  "Trim the result string.
Argument STR the result evaluated."
  (with-temp-buffer
    (insert (s-trim
             (s-chop-suffix
              ob-scala-cli-prompt-str
              (s-chop-prefix
               "}"
               (s-trim
                (s-join "" (cdr (s-split ob-scala-cli-eval-needle str))))))))
    (delete-trailing-whitespace)
    (buffer-string)))
```
… which comes in the end in a case of `:no-closure`

# Solutions

## Parsing each Scala REPL result

Blocks are executed one after another if we add `:no-closure`.
I tried this way, but it is hard to implement and maintain because of a lot of cases:
- one or multi line input
- `:no-closure` enable or disabled
- a success or a failure

## The best, but obsolete - :pa

Pros:
1. `:no-closure` is not needed.
2. Shows the right line of errors!

Cons: not supported anymore in Scala 3: https://users.scala-lang.org/t/solved-cannot-use-paste-in-scala3-repl/7587 ( https://github.com/lampepfl/dotty-feature-requests/issues/131 )

With this feature we could remove the `:no-closure` switch and even remove `ob-scala-cli-eval-needle`, because `:pa:` always works perfect. Also it is easy to implement:
```elisp
(defun org-babel-execute:scala (body params)
  ;; ...
    (comint-send-string scala-cli-repl-buffer-name ":pa\n")
    (comint-send-string scala-cli-repl-buffer-name full-body)
    (comint-send-string scala-cli-repl-buffer-name "\C-d")
  ;; ...
```

## Intermediate file - :load

Pros:
1. Scala 2.13 and dotty both support `:load`.
2. `:no-closure` is not needed.
3. Shows the right line of errors!

Cons: additional I/O operations.

1. Create a temporary file with the contents of org-babel block
2. Use `:load "/path/to/the/temp/file.scala"`

How an example with objects looks in REPL (actually, this file is not temporary, just an example):
```
scala> :load "/tmp/scala-cli-repl/test-objs.scala"
val args: Array[String] = Array()
Loading /tmp/scala-cli-repl/test-objs.scala...
object Foo

           println("error")
                  ^
/tmp/scala-cli-repl/test-objs.scala:3: error: type mismatch;
        found   : Unit
        required: Int
object Baz

scala>
```

We could improve this and pre-process the result before showing in `#+RESULTS`:
1. Remove all lines before and including "Loading ..."
2. Replace "/tmp/scala-cli-repl/test-objs.scala:" by "On line ", because a path to a temporary file is not interesting
3. We could go further with this approach and use it always. How an example with functions looks in REPL:
    ```
    scala> :load "/tmp/scala-cli-repl/test-funcs.scala"
    val args: Array[String] = Array()
    Loading /tmp/scala-cli-repl/test-funcs.scala...
    def foo(a: Int): Int

             println("error")
                ^
    /tmp/scala-cli-repl/test-funcs.scala:2: error: type mismatch;
            found   : Unit
            required: Int
    def baz(a: Int): Int
    ```

Actually, I did all improvements.

# Final words

Later I found another issue that I haven't solved. `*Scala CLI*` buffer works unexpectedly if it was created by `org-babel`: I see control symbols as squares, backspace and arrow keys don't work and other problems when I'm trying to interact with it manually. Probably, `comint-mode` will help here and maybe I'll fix this someday. 