### PR TITLE
Trim ellipses after /repl.sc in Scala 2

### DIFF
--- a/ob-scala-cli.el
+++ b/ob-scala-cli.el
@@ -161,7 +161,7 @@ Argument PARAMS the header arguments."
 (defun ob-scala-cli--parse-response-2 (file response)
   "Parse the result of a Scala 2 RESPONSE removing FILE mention."
   (->> response
-       (s-split "/repl.sc") ; the first part (loading ...) is not interesting
+       (s-split "/repl.sc...") ; the first part (loading ...) is not interesting
        last
        (s-join "")
        (s-replace ob-scala-cli-prompt-str "") ; remove "scala>"


### PR DESCRIPTION
It looks like we're getting extra output on the `:load` command, in Scala 2 only.

```
scala> :load /var/folders/8v/3gkf6_rj69d3_h9wnl3cw7pm0000gn/T/ob-scala-cli/repl.sc
val args: Array[String] = Array()
Loading /var/folders/8v/3gkf6_rj69d3_h9wnl3cw7pm0000gn/T/ob-scala-cli/repl.sc...
val res0: Int = 4
```

This manifests on f9b8c86aecce663014926a5023594512edc4e291 as ellipses in the results:

```org
#+begin_src scala :scala-version 2.13.12
  2+2
#+end_src

#+RESULTS:
: ...
: val res1: Int = 4
```

With this patch:

```org
#+begin_src scala :scala-version 2.13.12
  2+2
#+end_src

#+RESULTS:
: val res2: Int = 4
```